### PR TITLE
CATS-3055 | Avoid erroring on pages with deleted revisions

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -137,12 +137,8 @@
 		"remoteExtPath": "Thanks/modules"
 	},
 	"Hooks": {
-		"HistoryTools": [
-			"ThanksHooks::historyToolsAndDiffRevisionToolsHooksHandler"
-		],
-		"DiffRevisionTools": [
-			"ThanksHooks::historyToolsAndDiffRevisionToolsHooksHandler"
-		],
+		"HistoryTools": "main",
+		"DiffTools": "main",
 		"PageHistoryBeforeList": [
 			"ThanksHooks::onPageHistoryBeforeList"
 		],
@@ -167,6 +163,12 @@
 		"LogEventsListLineEnding": [
 			"ThanksHooks::onLogEventsListLineEnding"
 		]
+	},
+	"HookHandlers": {
+		"main": {
+			"class": "ThanksHooks",
+			"services": ["UserFactory"]
+		}
 	},
 	"config": {
 		"ThanksSendToBots": {


### PR DESCRIPTION
In 71f4dafa84f15a7979955b1d73501d7a65247078, the ThanksMeToo extension
was updated to work with MediaWiki 1.37. As part of this work, the
extension was migrated to use the new RevisionRecord class instead of
the now-removed Revision class.

The old Revision::getUser() method would return the user ID of the
author, or null if the given revision was deleted and the target
audience was not authorized to view the deleted info. By contrast, the
new RevisionRecord::getUser() method returns an UserIdentity instance or
null for the above case. This resulted in a regression as the updated
code did not perform a null check on the returned UserIdentity before
attempting to obtain its user ID via getId(), resulting in a PHP Error.
This would prevent accessing the page history of any page that had
deleted revisions.

As a fix, ensure we null-check the return value of getUser() to avoid
erroring out in this scenario. Also switch the relevant code to
explicitly use new-style hook handlers: it was referencing a removed
DiffRevisionTools, which should have been migrated to DiffTools.